### PR TITLE
Sort icon definitions by name in sprite

### DIFF
--- a/lib/SvgSprite.js
+++ b/lib/SvgSprite.js
@@ -85,8 +85,14 @@ class SvgSprite {
 
         let symbols = [];
 
+        const sortedKeys = Object.keys(icons).sort((a, b) => {
+            const nameA = icons[a].name.toLowerCase();
+            const nameB = icons[b].name.toLowerCase();
+            return (nameA < nameB) ? -1 : (nameA > nameB) ? 1 : 0;
+        });
+
         // For every icon in the sprite
-        for (let iconPath in icons) {
+        sortedKeys.forEach((iconPath) => {
 
             // Get the icon metadata
             const icon = icons[iconPath];
@@ -108,7 +114,7 @@ class SvgSprite {
                 x = 0;
                 y += ICON_HEIGHT;
             }
-        }
+        });
 
         // Generate the sprite content with the following format:
         // <svg>

--- a/package.json
+++ b/package.json
@@ -44,5 +44,5 @@
   "scripts": {
     "lint": "eslint index.js lib"
   },
-  "version": "0.3.4"
+  "version": "0.4.0"
 }


### PR DESCRIPTION
Sort the icon definitions by name in the sprite as although our import order wasn’t changing sometimes the sprite would be built with different definition order; causing a file change to occur when nothing was changing between builds.